### PR TITLE
kerberos, versions (pom), api, refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 *.iml
 .settings/
+tmp/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.cloudera</groupId>
 	<artifactId>spark-hbase</artifactId>
-	<version>0.0.2-clabs</version>
+	<version>1.0.0</version>
 	<packaging>jar</packaging>
 
 	<name>Spark HBase Integration</name>
@@ -12,6 +12,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<hbase.version>1.1.1</hbase.version>
+		<spark.version>1.4.1</spark.version>
 	</properties>
 
 	<dependencies>
@@ -29,12 +31,12 @@
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-core_2.10</artifactId>
-			<version>1.2.0-cdh5.3.0</version>
+			<version>${spark.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-streaming_2.10</artifactId>
-			<version>1.2.0-cdh5.3.0</version>
+			<version>${spark.version}</version>
 			<type>test-jar</type>
 			<classifier>tests</classifier>
 			<!-- <scope>test</scope> Return-->
@@ -42,17 +44,17 @@
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-streaming_2.10</artifactId>
-			<version>1.2.0-cdh5.3.0</version>
+			<version>${spark.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-client</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-client</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 			<type>test-jar</type>
 			<classifier>tests</classifier>
 			<scope>test</scope>
@@ -60,30 +62,30 @@
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-server</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-server</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 			<type>test-jar</type>
 			<!-- <classifier>tests</classifier> Return-->
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-protocol</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-hadoop2-compat</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 			<!-- <scope>runtime</scope> --> 
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-hadoop2-compat</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 			<type>test-jar</type>
 			<classifier>tests</classifier>
 			<!-- <scope>test</scope> Return-->
@@ -91,12 +93,12 @@
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-common</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-common</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 			<type>test-jar</type>
 			<classifier>tests</classifier>
 			<!-- <scope>test</scope> Return-->
@@ -104,13 +106,13 @@
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-hadoop-compat</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 			<!-- <scope>test</scope> Return-->
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-hadoop-compat</artifactId>
-			<version>0.98.6-cdh5.3.0</version>
+			<version>${hbase.version}</version>
 			<type>test-jar</type>
 			<classifier>tests</classifier>
 			<!-- <scope>test</scope> Return-->

--- a/src/main/scala/com/cloudera/spark/hbase/JavaHBaseContext.scala
+++ b/src/main/scala/com/cloudera/spark/hbase/JavaHBaseContext.scala
@@ -1,21 +1,12 @@
 package com.cloudera.spark.hbase
 
-import org.apache.spark.api.java.JavaSparkContext
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.api.java.JavaRDD
-import org.apache.spark.api.java.function.VoidFunction
-import org.apache.spark.api.java.function.Function
-import org.apache.hadoop.hbase.client.HConnection
+import org.apache.hadoop.hbase.client.{Delete, Get, HConnection, Increment, Put, Result, Scan}
+import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
+import org.apache.spark.api.java.function.{FlatMapFunction, Function, VoidFunction}
 import org.apache.spark.streaming.api.java.JavaDStream
-import org.apache.spark.api.java.function.FlatMapFunction
+
 import scala.collection.JavaConversions._
-import org.apache.hadoop.hbase.client.Put
-import org.apache.hadoop.hbase.client.Increment
-import org.apache.hadoop.hbase.client.Delete
-import org.apache.hadoop.hbase.client.Get
-import org.apache.hadoop.hbase.client.Result
-import org.apache.hadoop.hbase.client.Scan
-import org.apache.hadoop.hbase.io.ImmutableBytesWritable
 import scala.reflect.ClassTag
 
 class JavaHBaseContext(@transient jsc: JavaSparkContext,
@@ -362,39 +353,19 @@ class JavaHBaseContext(@transient jsc: JavaSparkContext,
         (r:Result) => convertResult.call(r) )(fakeClassTag[U]))(fakeClassTag[U])
   }
    
+
   /**
-   * This function will use the native HBase TableInputFormat with the
-   * given scan object to generate a new JavaRDD
-   *
-   *  @param tableName the name of the table to scan
-   *  @param scans      the HBase scan object to use to read data from HBase
-   *  @param f         function to convert a Result object from HBase into
-   *                   what the user wants in the final generated JavaRDD
-   *  @return          new JavaRDD with results from scan
-   */
-  def hbaseRDD[U](tableName: String, 
-      scans: Scan,
-      f: Function[(ImmutableBytesWritable, Result), U]): 
-      JavaRDD[U] = {
-    JavaRDD.fromRDD(
-        hbc.hbaseRDD[U](tableName, 
-            scans, 
-            (v:(ImmutableBytesWritable, Result)) => 
-              f.call(v._1, v._2))(fakeClassTag[U]))(fakeClassTag[U])
-  } 
-  
-  /**
-   * A overloaded version of HBaseContext hbaseRDD that predefines the
+   * A overloaded version of HBaseContext hbaseScanRDD that predefines the
    * type of the outputing JavaRDD
    *
    *  @param tableName the name of the table to scan
-   *  @param scans      the HBase scan object to use to read data from HBase
+   *  @param scan      the HBase scan object to use to read data from HBase
    *  @return New JavaRDD with results from scan
    *
    */
-  def hbaseRDD(tableName: String, 
-      scans: Scan): JavaRDD[(Array[Byte], java.util.List[(Array[Byte], Array[Byte], Array[Byte])])] = {
-    JavaRDD.fromRDD(hbc.hbaseRDD(tableName, scans))
+
+  def hbaseScanRDD(tableName: String, scan: Scan) = {
+    JavaRDD.fromRDD(hbc.hbaseScanRDD(tableName,scan))
   }
 
   /**

--- a/src/main/scala/com/cloudera/spark/hbase/Security.scala
+++ b/src/main/scala/com/cloudera/spark/hbase/Security.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.spark.hbase
+
+import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod
+import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+import org.apache.spark.Logging
+import org.apache.spark.deploy.SparkHadoopUtil
+
+/**
+ * Class for management of credentials on single machine in cluster
+ */
+object Security extends Logging {
+
+  val credentials = SparkHadoopUtil.get.getCurrentUserCredentials()
+  @transient val ugi = UserGroupInformation.getCurrentUser
+  //ugi.addCredentials(credentials) //add default credentials
+  // specify that this is a proxy user
+  ugi.setAuthenticationMethod(AuthenticationMethod.PROXY)
+
+  /**
+   * add specific credentials for the current user
+   * e.g. Kerberos credentials obtained from master
+   * @param cred credentials to add to the current user
+   */
+  def applyCreds(cred : Credentials) {
+      ugi.addCredentials(cred)
+  }
+
+}


### PR DESCRIPTION
add credentials management for Kerberos cluster (Scala object to have one instance per JVM and one point of credential management), delete scanRDD method not able to work with Kerberos (remain only hbaseScanRDD), some refactoring and sweeping of code (e.g. deprecated API), add HBase 1.1.1 and Spark 1.4.1 to pom, update version because of change in API
