### PR TITLE
Infinite loop when loglevel above info

### DIFF
--- a/src/main/scala/com/cloudera/spark/hbase/HBaseContext.scala
+++ b/src/main/scala/com/cloudera/spark/hbase/HBaseContext.scala
@@ -233,7 +233,8 @@ class HBaseContext(@transient sc: SparkContext,
     }
     val it = credentials2.getAllTokens.iterator();
     while (it.hasNext) {
-      logInfo("getAllTokens:" + it.next());
+      val newToken = it.next
+      logInfo("getAllTokens:" + newToken);
     }
   }
 


### PR DESCRIPTION
When setting loglevel above INFO, HbaseContext#logCredInformation will go into an endless loop. Logging is lazy evaluated and will not execute the line, thus not going through the iterator.

Spark 1.5.0 sets loglevels to WARN by default.
